### PR TITLE
Export all public symbols from the rake module.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-module.exports.keywordsAndScores = require('./lib/rake').keywordsAndScores;
+module.exports = require('./lib/rake');

--- a/lib/rake.js
+++ b/lib/rake.js
@@ -71,7 +71,7 @@ function keywords(text, stops) {
   // First, split by punctuation an new lines
   // '(?![ts]) means only match ' if not followed by t or s
   // (so as to not split isn't and dave's)
-  var blocksWithStops = text.split(/\n|\-|\.|\?|\(|\)|;|:|,|…|'(?![tsv])|"|“|”|–|•/);
+  var blocksWithStops = text.split(/\n|\*|\/|\]|\[|!|\-|\.|\?|\(|\)|;|:|,|…|'(?![tsv])|"|“|”|–|•/);
 
   blocksWithStops.forEach(function(blockWithStops) {
 

--- a/lib/rake.js
+++ b/lib/rake.js
@@ -62,8 +62,8 @@ function keywordsAndScores(text, stops) {
  */
 function keywords(text, stops) {
   var result = {};
-  result.candidates = {};
-  result.components = {};
+  result.candidates = Object.create(null); // The only safeish way to use as a map
+  result.components = Object.create(null);
 
   if (stops === undefined)
     stops = defaultStops;

--- a/lib/rake.js
+++ b/lib/rake.js
@@ -69,7 +69,9 @@ function keywords(text, stops) {
     stops = defaultStops;
 
   // First, split by punctuation an new lines
-  var blocksWithStops = text.split(/\n|\.|\?|;|:|,|…|'|"|“|”|–|•/);
+  // '(?![ts]) means only match ' if not followed by t or s
+  // (so as to not split isn't and dave's)
+  var blocksWithStops = text.split(/\n|\.|\?|\(|\(|;|:|,|…|'(?![ts])|"|“|”|–|•/);
 
   blocksWithStops.forEach(function(blockWithStops) {
 

--- a/lib/rake.js
+++ b/lib/rake.js
@@ -71,7 +71,7 @@ function keywords(text, stops) {
   // First, split by punctuation an new lines
   // '(?![ts]) means only match ' if not followed by t or s
   // (so as to not split isn't and dave's)
-  var blocksWithStops = text.split(/\n|\.|\?|\(|\)|;|:|,|…|'(?![ts])|"|“|”|–|•/);
+  var blocksWithStops = text.split(/\n|\.|\?|\(|\)|;|:|,|…|'(?![tsv])|"|“|”|–|•/);
 
   blocksWithStops.forEach(function(blockWithStops) {
 

--- a/lib/rake.js
+++ b/lib/rake.js
@@ -71,7 +71,7 @@ function keywords(text, stops) {
   // First, split by punctuation an new lines
   // '(?![ts]) means only match ' if not followed by t or s
   // (so as to not split isn't and dave's)
-  var blocksWithStops = text.split(/\n|\*|\/|\]|\[|!|\-|\.|\?|\(|\)|;|:|,|…|'(?![tsv])|"|“|”|–|•/);
+  var blocksWithStops = text.split(/\n|\*|\/|\]|\[|!|\-|\.|\?|\(|\)|_|=|;|:|,|…|'(?![tsv])|"|“|”|–|•/);
 
   blocksWithStops.forEach(function(blockWithStops) {
 

--- a/lib/rake.js
+++ b/lib/rake.js
@@ -71,7 +71,7 @@ function keywords(text, stops) {
   // First, split by punctuation an new lines
   // '(?![ts]) means only match ' if not followed by t or s
   // (so as to not split isn't and dave's)
-  var blocksWithStops = text.split(/\n|\.|\?|\(|\)|;|:|,|…|'(?![tsv])|"|“|”|–|•/);
+  var blocksWithStops = text.split(/\n|\-|\.|\?|\(|\)|;|:|,|…|'(?![tsv])|"|“|”|–|•/);
 
   blocksWithStops.forEach(function(blockWithStops) {
 

--- a/lib/rake.js
+++ b/lib/rake.js
@@ -71,7 +71,7 @@ function keywords(text, stops) {
   // First, split by punctuation an new lines
   // '(?![ts]) means only match ' if not followed by t or s
   // (so as to not split isn't and dave's)
-  var blocksWithStops = text.split(/\n|\.|\?|\(|\(|;|:|,|…|'(?![ts])|"|“|”|–|•/);
+  var blocksWithStops = text.split(/\n|\.|\?|\(|\)|;|:|,|…|'(?![ts])|"|“|”|–|•/);
 
   blocksWithStops.forEach(function(blockWithStops) {
 


### PR DESCRIPTION
This exposes everything in exports.<foo> to allow rake to work as a
regular node module.  (It seems that you were only exporting one of the symbols previously,
but there are a few other useful functions included in exports.
